### PR TITLE
Feature: User Identifier Hashing

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -3,7 +3,7 @@
 {
   "type": "TAG",
   "id": "cvt_temp_public_id",
-  "version": 1,
+  "version": 1.1,
   "securityGroups": [],
   "displayName": "inQuba Journey Tracker",
   "categories": [


### PR DESCRIPTION
This PR adds a feature to hash end user identifiers by default.
- An additional checkbox (on by default) is present to turn hashing of end user identifiers (user ID, phone, email) on or off
- When the checkbox is on, all end user ID values will be a SHA256 hash of the actual value